### PR TITLE
Fix/react dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## v0.16.0
 ### Changed
-- `react`, `react-dom` and `enzyme` are peer dependencies now. This may break your tests if those dependencies aren't listed in your `package.json`.
+- `react`, `react-dom`, `expect` and `enzyme` are peer dependencies now. This may break your tests if those dependencies aren't listed in your `package.json`.
 
 ### Added
 - New `.toHaveRendered()` assertion.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 `expect-enzyme` uses [this changelog style](http://keepachangelog.com/en/0.3.0/) and follows [semver](http://semver.org/).
 
 ## v0.16.0
+### Changed
+- `react`, `react-dom` and `enzyme` are peer dependencies now. This may break your tests if those dependencies aren't listed in your `package.json`.
+
 ### Added
 - New `.toHaveRendered()` assertion.
 - New `.toNotHaveRendered()` assertion.

--- a/README.md
+++ b/README.md
@@ -55,10 +55,17 @@ You get the idea.
 
 ```sh
 # npm
-npm install expect-enzyme --save-dev
+npm install expect expect-enzyme --save-dev
 
 # yarn
-yarn add expect-enzyme --dev
+yarn add expect expect-enzyme --dev
+```
+
+If node starts yelling about missing packages, you might wanna install this stuff too... ([more details](http://airbnb.io/enzyme/docs/installation/index.html))
+
+```sh
+# Setup is weird. This should help.
+yarn add enzyme react react-dom react-test-renderer --dev
 ```
 
 ### Extending

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "author": "Jesse Gibson",
   "dependencies": {
     "deep-eql": "^2.0.2",
-    "expect": "^1.20.2",
     "react-display-name": "^0.2.0",
     "stringify-object": "^3.2.0"
   },
@@ -38,14 +37,17 @@
     "eslint": "^3.19.0",
     "eslint-config-llama": "^3.0.0",
     "eslint-plugin-react": "^7.0.1",
+    "expect": "^1.20.2",
     "jsdom": "^11.0.0",
     "mocha": "^3.4.2",
     "prop-types": "^15.5.10",
     "react": "^15.5.4",
-    "react-addons-test-utils": "^15.5.1"
+    "react-addons-test-utils": "^15.5.1",
+    "react-dom": "^15.5.4"
   },
   "peerDependencies": {
     "enzyme": "2.x.x",
+    "expect": "1.x.x",
     "react": "13.0.0 - 15.x.x",
     "react-dom": "13.0.0 - 15.x.x"
   }

--- a/package.json
+++ b/package.json
@@ -26,23 +26,27 @@
   "author": "Jesse Gibson",
   "dependencies": {
     "deep-eql": "^2.0.2",
-    "enzyme": "2.x.x",
     "expect": "^1.20.2",
-    "react": "13.0.0 - 15.x.x",
     "react-display-name": "^0.2.0",
-    "react-dom": "13.0.0 - 15.x.x",
     "stringify-object": "^3.2.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
+    "enzyme": "^2.8.2",
     "eslint": "^3.19.0",
     "eslint-config-llama": "^3.0.0",
     "eslint-plugin-react": "^7.0.1",
     "jsdom": "^11.0.0",
-    "mocha": "^3.4.1",
+    "mocha": "^3.4.2",
     "prop-types": "^15.5.10",
+    "react": "^15.5.4",
     "react-addons-test-utils": "^15.5.1"
+  },
+  "peerDependencies": {
+    "enzyme": "2.x.x",
+    "react": "13.0.0 - 15.x.x",
+    "react-dom": "13.0.0 - 15.x.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "mocha": "^3.4.2",
     "prop-types": "^15.5.10",
     "react": "^15.5.4",
-    "react-addons-test-utils": "^15.5.1",
-    "react-dom": "^15.5.4"
+    "react-dom": "^15.5.4",
+    "react-test-renderer": "^15.5.4"
   },
   "peerDependencies": {
     "enzyme": "2.x.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1245,7 +1245,7 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-fbjs@^0.8.4, fbjs@^0.8.9:
+fbjs@^0.8.9:
   version "0.8.9"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.9.tgz#180247fbd347dcc9004517b904f865400a0c8f14"
   dependencies:
@@ -2336,13 +2336,6 @@ rc@~1.1.6:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-addons-test-utils@^15.5.1:
-  version "15.5.1"
-  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.5.1.tgz#e0d258cda2a122ad0dff69f838260d0c3958f5f7"
-  dependencies:
-    fbjs "^0.8.4"
-    object-assign "^4.1.0"
-
 react-display-name@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/react-display-name/-/react-display-name-0.2.0.tgz#0e1f7086e45a32d07764df35ed32ff16f1259790"
@@ -2355,6 +2348,13 @@ react-dom@^15.5.4:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
     prop-types "~15.5.7"
+
+react-test-renderer@^15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.5.4.tgz#d4ebb23f613d685ea8f5390109c2d20fbf7c83bc"
+  dependencies:
+    fbjs "^0.8.9"
+    object-assign "^4.1.0"
 
 react@^15.5.4:
   version "15.5.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2305,7 +2305,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@~15.5.7:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
@@ -2346,6 +2346,15 @@ react-addons-test-utils@^15.5.1:
 react-display-name@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/react-display-name/-/react-display-name-0.2.0.tgz#0e1f7086e45a32d07764df35ed32ff16f1259790"
+
+react-dom@^15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.5.4.tgz#ba0c28786fd52ed7e4f2135fe0288d462aef93da"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.0"
+    prop-types "~15.5.7"
 
 react@^15.5.4:
   version "15.5.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -988,7 +988,7 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-enzyme@2.x.x:
+enzyme@^2.8.2:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-2.8.2.tgz#6c8bcb05012abc4aa4bc3213fb23780b9b5b1714"
   dependencies:
@@ -2040,9 +2040,9 @@ mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mocha@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.4.1.tgz#a3802b4aa381934cacb38de70cf771621da8f9af"
+mocha@^3.4.2:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.4.2.tgz#d0ef4d332126dbf18d0d640c9b382dd48be97594"
   dependencies:
     browser-stdout "1.3.0"
     commander "2.9.0"
@@ -2305,7 +2305,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@~15.5.7:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
@@ -2347,16 +2347,7 @@ react-display-name@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/react-display-name/-/react-display-name-0.2.0.tgz#0e1f7086e45a32d07764df35ed32ff16f1259790"
 
-"react-dom@13.0.0 - 15.x.x":
-  version "15.5.4"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.5.4.tgz#ba0c28786fd52ed7e4f2135fe0288d462aef93da"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "~15.5.7"
-
-"react@13.0.0 - 15.x.x":
+react@^15.5.4:
   version "15.5.4"
   resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
   dependencies:


### PR DESCRIPTION
Puts `expect`, `enzyme`, `react`, and `react-dom` as peerDependencies. This fixes some versioning issues.