### PR TITLE
Fix case where className is undefined

### DIFF
--- a/src/assertions.js
+++ b/src/assertions.js
@@ -265,7 +265,10 @@ export default (original) => ({
 
       // Only works for enzyme elements.
       assertIsEnzymeWrapper(element);
-      const actual = element.prop('className').split(' ');
+      const actual = element.prop('className')
+        ? element.prop('className').split(' ')
+        : [];
+
       let expected = String(className).split(' ');
 
       if (isNegated(this)) {

--- a/src/test.js
+++ b/src/test.js
@@ -230,6 +230,19 @@ describe('expect-enzyme', () => {
         ]);
       }
     });
+
+    it('shows a diff when the className is undefined', () => {
+      const element = shallow(<div />);
+
+      try {
+        expect(element).toHaveClass('non-existent-class');
+        throw new Error('Should have thrown');
+      } catch (error) {
+        expect(error.message).toNotMatch(/(thrown|split)/);
+        expect(error.actual).toEqual([]);
+        expect(error.expected).toEqual(['non-existent-class']);
+      }
+    });
   });
 
   describe('toNotHaveClass()', () => {


### PR DESCRIPTION
One of the assertions was trying to string split on a potentially null
value.