### PR TITLE
Add check to `.toNotHaveRendered()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 `expect-enzyme` uses [this changelog style](http://keepachangelog.com/en/0.3.0/) and follows [semver](http://semver.org/).
 
 ## Unreleased
+### Added
+- Ability to call `.toNotHaveRendered()` on non-existent elements (throws if any parameters are given).
+
 ### Fixed
 - Deep equal check `.to(Not)HaveProp` value.
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "lint-staged": {
     "*.js": [
-      "npm run prettier -- --write"
+      "npm run prettier -- --write",
+      "git add"
     ]
   },
   "repository": {

--- a/src/assertions.js
+++ b/src/assertions.js
@@ -327,6 +327,16 @@ export default original => ({
   toHaveRendered: addEnzymeSupport(original.toHaveRendered, function(element) {
     const { actual } = this;
 
+    if (isNegated(this) && !actual.length) {
+      assert({
+        statement: element === undefined,
+        msg:
+          '.toNotHaveRendered(...) was given args, but no element was found.',
+      });
+
+      return;
+    }
+
     assert({
       ctx: this,
       statement: actual.equals(element),

--- a/src/test.js
+++ b/src/test.js
@@ -471,6 +471,12 @@ describe('expect-enzyme', () => {
 
       expect(assertion).toNotThrow(/:/);
     });
+
+    it('throws if the element does not exist', () => {
+      const assertion = () => expect(element.find('Nope')).toHaveRendered();
+
+      expect(assertion).toThrow();
+    });
   });
 
   describe('toNotHaveRendered()', () => {
@@ -495,6 +501,19 @@ describe('expect-enzyme', () => {
         expect(element).toNotHaveRendered(<button disabled value="Click me" />);
 
       expect(assertion).toThrow();
+    });
+
+    it('passes if the element does not exist', () => {
+      const assertion = () => expect(element.find('Nope')).toNotHaveRendered();
+
+      expect(assertion).toNotThrow();
+    });
+
+    it('throws if args are given when the component does not exist', () => {
+      const assertion = () =>
+        expect(element.find('Nope')).toNotHaveRendered(<div />);
+
+      expect(assertion).toThrow(/render/i);
     });
   });
 


### PR DESCRIPTION
Now you can call it on non-existent elements. It'll throw if you pass it
any arguments, otherwise you might have false positives.

Relates to issue #18 