### PR TITLE
Allow `.toHaveRendered()` to work without args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 `expect-enzyme` uses [this changelog style](http://keepachangelog.com/en/0.3.0/) and follows [semver](http://semver.org/).
 
+## v1.2.0
+### Added
+- Ability to call `.toHaveRendered()`/`.toNotHaveRendered()` without arguments.
+
 ## v1.1.2
 ### Fixed
 - Use deep equality (not strict equality) when checking `.to(Not)HaveProp` values.

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Error: Expected state "clickCount" to equal 3
 > Negation: `.toNotHaveState()`
 
 #### `.toHaveRendered(element)`
-Asserts the component rendered the given value.
+Asserts the component rendered the given value, or just that it rendered _something_.
 
 ```js
 // The first event looks exactly like this.
@@ -298,6 +298,9 @@ expect(listOfRegrets).toHaveRendered(null)
 
 // I don't trust this button.
 expect(stockAdvice).toHaveRendered(<button disabled={false}>Buy now!</button>)
+
+// It exists and it didn't render `null`.
+expect(singers.find('Elvis')).toHaveRendered()
 ```
 
 ##### Error
@@ -310,6 +313,8 @@ Error: Expected element to equal "null"
 
 Error: Expected element to equal:
    <button disabled={false}>Buy now!</button>
+
+Error: Expected element to have rendered something
 ```
 
 > Negation: `.toNotHaveRendered()`

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "lint-staged": {
     "*.js": [
-      "npm run prettier -- --write"
+      "npm run prettier -- --write",
+      "git add"
     ]
   },
   "repository": {

--- a/src/assertions.js
+++ b/src/assertions.js
@@ -334,17 +334,18 @@ export default original => ({
     if (negated && !exists && testEquality) {
       assert({
         statement: false,
-        msg: `Expected element not to match, but it didn't exist`,
+        msg: "Expected element not to match, but it didn't exist",
       });
     }
 
     // Handle cases where `.toHaveRendered()` was called with no args.
     if (!negated) {
-      const unexpectedNull = testEquality ? false : actual.equals(null);
+      const unexpectedNull =
+        !exists || testEquality ? false : actual.equals(null);
 
       assert({
         statement: exists && !unexpectedNull,
-        msg: `Expected element to have rendered`,
+        msg: `Expected element to have rendered something`,
       });
     }
 

--- a/src/assertions.js
+++ b/src/assertions.js
@@ -326,6 +326,32 @@ export default original => ({
    */
   toHaveRendered: addEnzymeSupport(original.toHaveRendered, function(element) {
     const { actual } = this;
+    const exists = Boolean(actual && actual.length);
+    const testEquality = element !== undefined;
+    const negated = isNegated(this);
+
+    // `.toNotHaveRendered(...)` called on non-existent element.
+    if (negated && !exists && testEquality) {
+      assert({
+        statement: false,
+        msg: `Expected element not to match, but it didn't exist`,
+      });
+    }
+
+    // Handle cases where `.toHaveRendered()` was called with no args.
+    if (!negated) {
+      const unexpectedNull = testEquality ? false : actual.equals(null);
+
+      assert({
+        statement: exists && !unexpectedNull,
+        msg: `Expected element to have rendered`,
+      });
+    }
+
+    // Being used as `.toExist()`.
+    if (!testEquality) {
+      return;
+    }
 
     assert({
       ctx: this,

--- a/src/test.js
+++ b/src/test.js
@@ -479,6 +479,12 @@ describe('expect-enzyme', () => {
       expect(assertion).toThrow(/render/i);
     });
 
+    it('throws if the element does not exist with no matcher', () => {
+      const assertion = () => expect(element.find('bacon')).toHaveRendered();
+
+      expect(assertion).toThrow(/render/i);
+    });
+
     it('does not throw if no elements were provided', () => {
       const assertion = () => expect(element).toHaveRendered();
 

--- a/src/test.js
+++ b/src/test.js
@@ -471,6 +471,27 @@ describe('expect-enzyme', () => {
 
       expect(assertion).toNotThrow(/:/);
     });
+
+    it('throws if the element does not exist', () => {
+      const assertion = () =>
+        expect(element.find('aside')).toHaveRendered(<div />);
+
+      expect(assertion).toThrow(/render/i);
+    });
+
+    it('does not throw if no elements were provided', () => {
+      const assertion = () => expect(element).toHaveRendered();
+
+      expect(assertion).toNotThrow();
+    });
+
+    it('throws if the value is null when no matcher was given', () => {
+      const Component = () => null;
+      const element = shallow(<Component />);
+      const assertion = () => expect(element).toHaveRendered();
+
+      expect(assertion).toThrow(/render/i);
+    });
   });
 
   describe('toNotHaveRendered()', () => {
@@ -494,7 +515,22 @@ describe('expect-enzyme', () => {
       const assertion = () =>
         expect(element).toNotHaveRendered(<button disabled value="Click me" />);
 
-      expect(assertion).toThrow();
+      expect(assertion).toThrow(/equal/i);
+    });
+
+    // If the user didn't expect it to exist, they wouldn't
+    // have passed an element to match against.
+    it('throws if the element does not exist', () => {
+      const assertion = () =>
+        expect(element.find('bacon')).toNotHaveRendered(<div />);
+
+      expect(assertion).toThrow(/exist/);
+    });
+
+    it('passes if the element does not exist but has no matcher', () => {
+      const assertion = () => expect(element.find('bacon')).toNotHaveRendered();
+
+      expect(assertion).toNotThrow();
     });
   });
 


### PR DESCRIPTION
Adds new behavior:
- `.toHaveRendered()` fails if it doesn't exist or rendered null
- `.toNotHaveRendered()` fails if it exists and didn't render null

(ideas pulled from issues #18 & #22)

This doesn't exactly duplicate `.toExist()`/`.toNotExist()`, since it also checks whether the component rendered `null`. These changes are only additive, I don't think anyone's been using those assertions without arguments. At least, I really hope not...

To prevent false positives in tests, calling `.toNotHaveRendered(...)` with an element will throw an assertion error if the element doesn't exist.