### PR TITLE
Fix/to have rendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 `expect-enzyme` uses [this changelog style](http://keepachangelog.com/en/0.3.0/) and follows [semver](http://semver.org/).
 
+## v1.2.1
+### Fixed
+- `.toHaveRendered()` without args was passing even if the element rendered non-null values.
+
 ## v1.2.0
 ### Added
 - Ability to call `.toHaveRendered()`/`.toNotHaveRendered()` without arguments.

--- a/src/assertions.js
+++ b/src/assertions.js
@@ -349,6 +349,13 @@ export default original => ({
       });
     }
 
+    if (negated && !testEquality) {
+      assert({
+        statement: !exists || actual.equals(null),
+        msg: `Expected element to not have rendered anything`,
+      });
+    }
+
     // Being used as `.toExist()`.
     if (!testEquality) {
       return;

--- a/src/test.js
+++ b/src/test.js
@@ -538,6 +538,12 @@ describe('expect-enzyme', () => {
 
       expect(assertion).toNotThrow();
     });
+
+    it('fails if the element rendered something with no matcher', () => {
+      const assertion = () => expect(element).toNotHaveRendered();
+
+      expect(assertion).toThrow(/render/i);
+    });
   });
 
   describe('toNotHaveState()', () => {


### PR DESCRIPTION
Fixes an issue where `.toNotHaveRendered()` passes even when the component rendered something non-null.

Addresses #22 